### PR TITLE
feat/hierarchy manage (hierarchy 관리용 utils)

### DIFF
--- a/Assets/Scripts/Utils/Hierarchy.meta
+++ b/Assets/Scripts/Utils/Hierarchy.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 69bb5a4de93decf48bbfa98108f2533a
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Utils/Hierarchy/GameObjectRoot.cs
+++ b/Assets/Scripts/Utils/Hierarchy/GameObjectRoot.cs
@@ -1,0 +1,14 @@
+using UnityEngine;
+
+namespace Utility.Hierarchy
+{
+   public class GameObjectRoot : RootObject
+   {
+      public static Transform Transform;
+      
+      protected override void Register()
+      {
+         Transform = transform;
+      }
+   }
+}

--- a/Assets/Scripts/Utils/Hierarchy/GameObjectRoot.cs.meta
+++ b/Assets/Scripts/Utils/Hierarchy/GameObjectRoot.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e1dd784c686aa154e872f6b1d861b318
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Utils/Hierarchy/PopupUIRoot.cs
+++ b/Assets/Scripts/Utils/Hierarchy/PopupUIRoot.cs
@@ -1,0 +1,13 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class PopupUIRoot : RootObject
+{
+    public static Transform Transform;
+      
+    protected override void Register()
+    {
+        Transform = transform;
+    }
+}

--- a/Assets/Scripts/Utils/Hierarchy/PopupUIRoot.cs.meta
+++ b/Assets/Scripts/Utils/Hierarchy/PopupUIRoot.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 414515f42a760ee409b1c491cfb00c4b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Utils/Hierarchy/RootObject.cs
+++ b/Assets/Scripts/Utils/Hierarchy/RootObject.cs
@@ -1,0 +1,13 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public abstract class RootObject : MonoBehaviour
+{
+    private void Awake()
+    {
+        Register();
+    }
+    
+    protected abstract void Register();
+}

--- a/Assets/Scripts/Utils/Hierarchy/RootObject.cs.meta
+++ b/Assets/Scripts/Utils/Hierarchy/RootObject.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 60bff9e5348c22c468ab1ac0ba8359a8
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Utils/Hierarchy/SceneUIRoot.cs
+++ b/Assets/Scripts/Utils/Hierarchy/SceneUIRoot.cs
@@ -1,0 +1,13 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class SceneUIRoot : RootObject
+{
+    public static Transform Transform;
+      
+    protected override void Register()
+    {
+        Transform = transform;
+    }
+}

--- a/Assets/Scripts/Utils/Hierarchy/SceneUIRoot.cs.meta
+++ b/Assets/Scripts/Utils/Hierarchy/SceneUIRoot.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e11a169661e4ea44f8535dda83fac575
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## 작업 내용
- Hierarchy 정돈을 위한 로직 추가
    - 원하는 프리팹을 인스턴스화 할 때 오브젝트 유형에 따라 Parent를 지정해 주기 위함
    - 각각의 scene에 존재하는 RootObject에 컴포넌트를 부착해서 적용 할 수 있음
        - ObjectRoot의 경우 `GameObjectRoot.cs`
        - PopupRoot의 경우 `PopupUIRoot.cs`
        - SceneUIRoot의 경우 `SceneUIRoot.cs` 를 부착

## 참고 자료
- 현재 스크립트만 작성되어있으며, 추후 Scene 작업 시 컴포넌트 부착 필요함

## 리뷰 요구사항
- 
